### PR TITLE
fix impl_binary depset

### DIFF
--- a/ocaml/_rules/impl_binary.bzl
+++ b/ocaml/_rules/impl_binary.bzl
@@ -481,7 +481,7 @@ def impl_binary(ctx): # , mode, tc, tool, tool_args):
 
         ,
         transitive =
-        [depset(direct = [ctx.file.main])]
+        [depset(direct = [ctx.file.main])] if ctx.file.main else []
         # data_inputs
         + sigs_secondary
         + structs_secondary


### PR DESCRIPTION
Fixes the error:

```
Error in depset: cannot add an item of type 'File' to a depset of 'NoneType'
```

I don't exactly understand the intricacies of this rule, maybe this depset should be totally removed?